### PR TITLE
moved chat window to my events/dashboard page

### DIFF
--- a/app/assets/stylesheets/components/_chat.scss
+++ b/app/assets/stylesheets/components/_chat.scss
@@ -1,0 +1,3 @@
+.hidden-chat {
+  // display: none;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -22,3 +22,4 @@
 @import "event-card";
 @import "filter";
 @import "message";
+@import "chat";

--- a/app/controllers/my/events_controller.rb
+++ b/app/controllers/my/events_controller.rb
@@ -5,6 +5,7 @@ class My::EventsController < ApplicationController
     @participations = policy_scope([:my, Registration.where(user: current_user)])
     group_events(@events, @participations)
     @events = @all_events
+    @message = Message.new
   end
 
   private

--- a/app/controllers/my/temp.rails
+++ b/app/controllers/my/temp.rails
@@ -1,0 +1,12 @@
+    <div class="inppp">
+      <% raise %>
+      <%= simple_form_for [ event, message ], remote: true do |f| %>
+        <%= f.input :content,as: :string,
+                         wrapper: false,
+                         label: false,
+                         input_html: {
+                           class: 'chat-input-area__input'
+                         }, label: false, placeholder: "Message ##{event.title}" %>
+        <%= f.submit value: " ", class: "chat-input-area__submit-button" %>
+        <% end %>
+    </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -66,24 +66,7 @@
           </div>
         </div>
       </div>
-      <div class="chat-container">
-              <div id="messages" data-event-id="<%= @event.id %>">
-                <% @event.messages.each do |message| %>
-                  <%= render "messages/message", message: message %>
-                <% end %>
-              </div>
-              <div class="inppp">
-                <%= simple_form_for [ @event, @message ], remote: true do |f| %>
-                  <%= f.input :content,as: :string,
-                                   wrapper: false,
-                                   label: false,
-                                   input_html: {
-                                     class: 'chat-input-area__input'
-                                   }, label: false, placeholder: "Message ##{@event.title}" %>
-                  <%= f.submit value: " ", class: "chat-input-area__submit-button" %>
-                  <% end %>
-              </div>
-               </div>
+
 
     <i class="fas fa-dice"></i>
       </div>

--- a/app/views/my/events/index.html.erb
+++ b/app/views/my/events/index.html.erb
@@ -8,7 +8,7 @@
 </div>
 <div class="container-fluid m-0 p-0">
   <div class="row">
-    <div class="col-8 pl-5 pr-5 mr-0 results">
+    <div class="col-7 pl-5 pr-5 mr-0 results">
       <div class="results-pane">
         <div class="results-header pt-3 pb-3 pl-2 mt-3">
           <h2 class="text-uppercase">Your Upcoming <span class="pink">Games</span></h2>
@@ -24,82 +24,9 @@
         </div>
       </div>
     </div>
-    <div class="col-4 ml-0">
+    <div class="col-5 ml-0">
       <div class="filter-pane">
-        <div class="filter-header text-center">
-          <p>Filters</p>
-        </div>
-        <div class="filter-group">
-          <div class="filter-title">
-            <p>Organising</p>
-          </div>
-          <div class="btn-group btn-group-toggle mb-3" data-toggle="buttons">
-            <label class="btn btn-secondary active rounded btn-filter">
-              <input type="radio" name="options" id="option1" checked> Host
-            </label>
-            <label class="btn btn-secondary rounded btn-filter">
-              <input type="radio" name="options" id="option2"> Participant
-            </label>
-            <label class="btn btn-secondary rounded btn-filter">
-              <input type="radio" name="options" id="option3"> All
-            </label>
-          </div>
-        </div>
-        <div class="filter-group">
-          <div class="filter-title">
-            <p>Date Around</p>
-          </div>
-          <div class="btn-group btn-group-toggle mb-3" data-toggle="buttons">
-            <label class="btn btn-secondary active rounded btn-filter">
-              <input type="radio" name="options" id="option1" checked> Next 24 hrs
-            </label>
-            <label class="btn btn-secondary rounded btn-filter">
-              <input type="radio" name="options" id="option2"> This week
-            </label>
-            <label class="btn btn-secondary rounded btn-filter">
-              <input type="radio" name="options" id="option3"> All
-            </label>
-          </div>
-        </div>
-          <div class="filter-group">
-          <div class="filter-title">
-            <p>Game</p>
-          </div>
-          <div class="btn-group btn-group-toggle mb-3 " data-toggle="buttons">
-            <div class="row d-flex justify-content-center">
-              <label class="btn btn-secondary active rounded btn-filter col-3">
-                <input type="radio" name="options" id="option1" checked> Chess
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option2"> Monopoly
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option3"> Catan
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option3"> Dominos
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option3"> Mancala
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option3"> Cranium
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option3"> Othello
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option3"> Stratego
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-3">
-                <input type="radio" name="options" id="option3"> Scrabble
-              </label>
-              <label class="btn btn-secondary rounded btn-filter col-10">
-                <input type="radio" name="options" id="option3"> All
-              </label>
-            </div>
-          </div>
-        </div>
+        <%= render "shared/chat" %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_chat.html.erb
+++ b/app/views/shared/_chat.html.erb
@@ -1,0 +1,20 @@
+<% @events.each do |event|  %>
+  <div class="chat-container hidden-chat" data-event-id = "<%= event.id %>">
+    <div id="messages" data-event-id="<%= event.id %>">
+      <% event.messages.each do |message| %>
+        <%= render "messages/message", message: message %>
+      <% end %>
+    </div>
+    <div class="inppp">
+      <%= simple_form_for [ event, @message ], remote: true do |f| %>
+        <%= f.input :content,as: :string,
+                         wrapper: false,
+                         label: false,
+                         input_html: {
+                           class: 'chat-input-area__input'
+                         }, label: false, placeholder: "Message ##{event.title}" %>
+        <%= f.submit value: " ", class: "chat-input-area__submit-button" %>
+        <% end %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
Changes made in this pull request:
>chat window now appears inside my events/ dashboard view.
>All individual chat windows are automatically populated for html, and then they are set to hidden (see _chat.scss, line commented out during development).

The next step to do:
>>Once a user clicks on a card, it should only show the respective chat window while keeping the rest hidden. I will do this in JS but will check with Stian first to make sure it doesn't break the code like last time.